### PR TITLE
Add exclude-hosts option

### DIFF
--- a/arg_parser.py
+++ b/arg_parser.py
@@ -17,6 +17,7 @@ class Options:
         csvFile           = [],
         includeShares     = [],
         excludeShares     = [],
+        excludeHosts     = [],
         maxDepth          = 0,
         patternsFile      = setup.OS_PATH_DEFAULT_PATTERN_PATH,
         downloadFiles     = 0
@@ -32,6 +33,7 @@ class Options:
         self.csvFile           = csvFile
         self.includeShares     = includeShares
         self.excludeShares     = excludeShares
+        self.excludeHosts      = excludeHosts
         self.maxDepth          = maxDepth,
         self.patternsFile      = patternsFile
         self.patterns          = []
@@ -86,6 +88,10 @@ def setup_command_line_args(args = None) -> argparse.Namespace:
     parser.add_argument(
         "--exclude-shares",
         help="List of comma separated shares to exclude from scan. All others will be included.",
+    )
+    parser.add_argument(
+        "--exclude-hosts",
+        help="List of comma separated hosts to exclude from scan.",
     )
     parser.add_argument(
         "--max-depth",

--- a/smbscan.py
+++ b/smbscan.py
@@ -45,6 +45,8 @@ def main():
         options.includeShares = str(args.include_shares).split(",")
     if str(args.exclude_shares) != "None":
         options.excludeShares = str(args.exclude_shares).split(",")
+    if str(args.exclude_hosts) != "None":
+        options.excludeHosts = str(args.exclude_hosts).split(",")
 
     with open(options.patternsFile, "r") as k_file:
         for line in k_file:


### PR DESCRIPTION
### Purpose

Add option to exclude hosts from scans (Issue https://github.com/jeffhacks/smbscan/issues/31)

### Description

Add `--exclude-hosts` option
Check current target against this list (if provided). Skip and display a warning if a match is found.

### Verification and Testing

Tested manually.

### Release Notes

Added option to exclude a comma separated list of hosts from the scan. (--exclude-hosts)
