### PR TITLE
Add additional control over jitter

### DIFF
--- a/arg_parser.py
+++ b/arg_parser.py
@@ -12,8 +12,8 @@ class Options:
         port              = 139,
         timeout           = 2,
         jitter            = 3,
-        jitter_target     = 3,
-        jitter_operation  = 3,
+        jitterTarget      = 3,
+        jitterOperation   = 3,
         aesKey            = "",
         dc_ip             = "",
         csvFile           = [],
@@ -30,8 +30,8 @@ class Options:
         self.port              = port
         self.timeout           = timeout
         self.jitter            = jitter
-        self.jitter_target     = jitter_target
-        self.jitter_operation  = jitter_operation
+        self.jitterTarget      = jitterTarget
+        self.jitterOperation   = jitterOperation
         self.aesKey            = aesKey
         self.dc_ip             = dc_ip
         self.csvFile           = csvFile

--- a/scan.py
+++ b/scan.py
@@ -77,5 +77,5 @@ def scan_single(targetHost, user, options):
             finally:
                 smbClient.close()
                 logFile.close()
-        if options.jitter_target > 0:
-            time.sleep(random.randint(0, options.jitter_target))
+        if options.jitterTarget > 0:
+            time.sleep(random.randint(0, options.jitterTarget))

--- a/scan_internals.py
+++ b/scan_internals.py
@@ -139,8 +139,8 @@ def list_files(target, smbClient, share, sharePath, options, logFile, currentDep
         logger.debug(f"{e}")
         return
     finally:
-        if options.jitter_operation > 0:
-            time.sleep(random.randint(0, options.jitter_operation))
+        if options.jitterOperation > 0:
+            time.sleep(random.randint(0, options.jitterOperation))
 
 def get_files(smbClient, target, options, logFile):
     for share in target.shares:

--- a/smbscan.py
+++ b/smbscan.py
@@ -31,8 +31,8 @@ def main():
     # Refactor Options - config file?
     options = Options()
     options.jitter            = args.jitter
-    options.jitter_target     = args.jitter if args.jitter_target is None else args.jitter_target
-    options.jitter_operation  = args.jitter if args.jitter_operation is None else args.jitter_operation
+    options.jitterTarget     = args.jitter if args.jitter_target is None else args.jitter_target
+    options.jitterOperation  = args.jitter if args.jitter_operation is None else args.jitter_operation
     options.timeout           = args.timeout
     options.logfile           = args.logfile
     options.csvFile           = (


### PR DESCRIPTION
### Purpose

Supplement jitter setting with separate settings for targets and operations. Issue https://github.com/jeffhacks/smbscan/issues/35

### Description

Supplement jitter setting with separate settings for targets and operations.

### Verification and Testing

Manual testing.

### Release Notes

Two new jitter settings added

Random delay before moving to next target. Default 3 seconds.
`-jt`
`--jitter-target`
        
Random delay between some file operations on target. Default 3 seconds.
`-jo`
`--jitter-operation`
        
