### PR TITLE
Enable scanning of NETLOGON and SYSVOL

### DIFF
--- a/scan_internals.py
+++ b/scan_internals.py
@@ -32,7 +32,7 @@ def get_shares(smbClient):
     resp = smbClient.listShares()
     for i in range(len(resp)):
         shareName = resp[i]["shi1_netname"][:-1]
-        if is_valid_share_name(shareName) and shareName not in ["NETLOGON", "SYSVOL", "IPC$", "print$"]:
+        if is_valid_share_name(shareName) and shareName not in ["IPC$", "print$"]:
             shares.append(Share(shareName))
     return shares
 


### PR DESCRIPTION
### Purpose

Enable scanning of NETLOGON and SYSVOL. (Issue #51)

### Description

Remove these two terms from the exclusion list.

### Verification and Testing

Manual testing with shares named NETLOGON and SYSVOL.

### Release Notes

Scans will now crawl NETLOGON and SYSVOL shares.