### PR TITLE
Add hash option

### DIFF
--- a/arg_parser.py
+++ b/arg_parser.py
@@ -69,6 +69,9 @@ def setup_command_line_args(args = None) -> argparse.Namespace:
     parser.add_argument(
         "-p", "--password", help="Password for user (will prompt if missing and needed)"
     )
+    parser.add_argument(
+        "-H", "--hash", help="NTLM Hash for user"
+    )
     parser.add_argument("-d", "--domain", help="Domain for user")
     parser.add_argument("-k", "--kerberos", help="Not implemented", action="store_true")
     parser.add_argument(

--- a/smbscan.py
+++ b/smbscan.py
@@ -75,7 +75,12 @@ def main():
     user = User()
     if args.user:
         user.username = args.user
-        user.password = args.password if args.password else getpass.getpass()
+        ntlmHash = args.hash
+        if ntlmHash:
+            user.lmhash = ntlmHash.split(':')[0]
+            user.nthash = ntlmHash.split(':')[1]
+        else:
+            user.password = args.password if args.password else getpass.getpass()
         user.domain   = args.domain if args.domain else ""
 
     logger = logging.getLogger('smbscan')


### PR DESCRIPTION
### Purpose

Add option to use a hash for authentication

### Description

Add option to perform scans using a username/NTLM hash combination instead of a username/password combination (Issue #53)

### Verification and Testing

Manual testing

### Release Notes

Add option to use a hash for authentication instead of supplying a password
- Use the `-H` option to pass in an NTLM hash 