### PR TITLE
Add include/exclude paths option

### DIFF
--- a/arg_parser.py
+++ b/arg_parser.py
@@ -21,6 +21,8 @@ class Options:
         dc_ip             = "",
         csvFile           = [],
         stateFile         = "",
+        includePaths      = [],
+        excludePaths      = [],
         includeShares     = [],
         excludeShares     = [],
         excludeHosts      = [],
@@ -42,6 +44,8 @@ class Options:
         self.dc_ip             = dc_ip
         self.csvFile           = csvFile
         self.stateFile         = stateFile
+        self.includePaths      = includePaths
+        self.excludePaths      = excludePaths
         self.includeShares     = includeShares
         self.excludeShares     = excludeShares
         self.excludeHosts      = excludeHosts
@@ -115,6 +119,14 @@ def setup_command_line_args(args = None) -> argparse.Namespace:
         "--log-directory",
         help="Override log file directory",
         default=os.path.join(os.getcwd(), "logs")
+    )
+    parser.add_argument(
+        "--include-paths",
+        help="List of comma separated paths to include in scan. All others will be excluded.",
+    )
+    parser.add_argument(
+        "--exclude-paths",
+        help="List of comma separated paths to exclude from scan. All others will be included.",
     )
     parser.add_argument(
         "--include-shares",

--- a/smbscan.py
+++ b/smbscan.py
@@ -61,6 +61,10 @@ def main():
     options.downloadFiles     = args.download_files
     options.logLevel          = logging.DEBUG if args.debug else logging.INFO
     
+    if str(args.include_paths) != "None":
+        options.includePaths = str(args.include_paths).split(",")
+    if str(args.exclude_paths) != "None":
+        options.excludePaths = str(args.exclude_paths).split(",")
     if str(args.include_shares) != "None":
         options.includeShares = str(args.include_shares).split(",")
     if str(args.exclude_shares) != "None":


### PR DESCRIPTION
### Purpose

Add ability to include or exclude paths within shares from scanning.

### Description

Add ability to include or exclude paths within shares from scanning.

### Verification and Testing

Manual testing

### Release Notes

Add ability to include or exclude paths within shares from scanning.
